### PR TITLE
Update standalone.html

### DIFF
--- a/standalone.html
+++ b/standalone.html
@@ -29,7 +29,7 @@
   
   <script src="script.js"></script>
   
-    <script src="jquery.sticky-kit.js "></script>
+    <script src="jquery.sticky-kit.js"></script>
   <meta name="generator" content="pandoc" />
 $for(author-meta)$
   <meta name="author" content="$author-meta$" />


### PR DESCRIPTION
Superfluous space causes problem when converting with pandoc `--self-contained` option.